### PR TITLE
Update gbk.sh

### DIFF
--- a/gbk.sh
+++ b/gbk.sh
@@ -30,7 +30,7 @@ rclone move --update --include "*.sql.zip" --verbose --transfers 30 --checkers 8
 echo "Clearing remote directory"
 
 # Delete old files from Google Drive
-rclone --drive-use-trash=false --verbose --min-age 60d delete "gdrive:${gdrive}/${backupDir}"
+rclone --drive-use-trash=false --verbose --min-age 2d delete "gdrive:${gdrive}/${backupDir}"
 
 # rclone --drive-use-trash=false --verbose --min-age 2d delete gdrive:db-backup
 


### PR DESCRIPTION
REduced the deletion windows from 60d to 2 days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reduced the minimum age for file deletion from 60 days to 2 days in the specified Google Drive directory using rclone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->